### PR TITLE
[#9] useFormFunnel 개발

### DIFF
--- a/src/entities/book/index.ts
+++ b/src/entities/book/index.ts
@@ -1,5 +1,6 @@
 export { default as BookCard } from './ui/BookCard';
 export { default as BookList } from './ui/BookList';
 export type { Book, BookDetail } from './model/book';
+export { useBookDetail } from './model/use-book-detail';
 export { BookListTab } from './model/book-list-tab';
 export { bookQueries } from './api/book-queries';

--- a/src/entities/book/model/use-book-detail.ts
+++ b/src/entities/book/model/use-book-detail.ts
@@ -1,0 +1,8 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { bookQueries } from '../api/book-queries';
+
+export function useBookDetail(isbn: string) {
+  const { data } = useSuspenseQuery(bookQueries.detail(isbn));
+
+  return data;
+}

--- a/src/features/book-note/model/book-note-form-step.ts
+++ b/src/features/book-note/model/book-note-form-step.ts
@@ -1,9 +1,0 @@
-export const BookNoteFormStep = {
-  READING_INFO: 'READING_INFO',
-  RATING: 'RATING',
-  REVIEW: 'REVIEW',
-  QUOTES: 'QUOTES',
-  VISIBILITY: 'VISIBILITY',
-} as const;
-
-export type BookNoteFormStep = (typeof BookNoteFormStep)[keyof typeof BookNoteFormStep];

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useParams } from 'next/navigation';
+import { FormProvider } from 'react-hook-form';
 import { useFormFunnel } from '@/shared/lib/form';
 import { RenderCase } from '@/shared/ui/render-case';
 import { useBookDetail } from '@/entities/book';
+import { BookNoteFormValues } from '../../model/book-note-form-values';
 import BookNoteFormActions from './BookNoteFormActions';
 import ReadingInfoStep from './step/ReadingInfoStep';
 import RatingStep from './step/RatingStep';
@@ -11,35 +13,51 @@ import ReviewStep from './step/ReviewStep';
 import QuotesStep from './step/QuotesStep';
 import VisibilityStep from './step/VisibilityStep';
 
+const triggerFields: Record<number, (keyof BookNoteFormValues)[]> = {
+  1: ['readingStatus', 'startDate', 'endDate'],
+  2: ['recommended', 'overallRating'],
+  3: ['content'],
+  4: ['quotes'],
+  5: ['visibility'],
+};
+
 export default function BookNoteForm() {
   const { isbn } = useParams<{ isbn: string }>()!;
 
   const book = useBookDetail(isbn);
 
-  const { navigation } = useFormFunnel({
+  const {
+    form,
+    navigation: { currentStep, isFirstStep, isLastStep, goToPreviousStep, goToNextStep },
+  } = useFormFunnel<BookNoteFormValues>({
     totalSteps: 5,
   });
 
-  const { currentStep, isFirstStep, isLastStep, goToPreviousStep, goToNextStep } = navigation;
+  const handleNext = async () => {
+    const isValid = await form.trigger(triggerFields[currentStep]);
+    if (isValid) goToNextStep();
+  };
 
   return (
-    <form className="mx-auto w-full max-w-4xl space-y-8 p-4 md:p-6">
-      <RenderCase
-        value={currentStep}
-        cases={{
-          1: <ReadingInfoStep book={book} />,
-          2: <RatingStep />,
-          3: <ReviewStep />,
-          4: <QuotesStep />,
-          5: <VisibilityStep />,
-        }}
-      />
-      <BookNoteFormActions
-        previousDisabled={isFirstStep}
-        nextDisabled={isLastStep}
-        onPrevious={goToPreviousStep}
-        onNext={goToNextStep}
-      />
-    </form>
+    <FormProvider {...form}>
+      <form className="mx-auto w-full max-w-4xl space-y-8 p-4 md:p-6">
+        <RenderCase
+          value={currentStep}
+          cases={{
+            1: <ReadingInfoStep book={book} />,
+            2: <RatingStep />,
+            3: <ReviewStep />,
+            4: <QuotesStep />,
+            5: <VisibilityStep />,
+          }}
+        />
+        <BookNoteFormActions
+          previousDisabled={isFirstStep}
+          nextDisabled={isLastStep}
+          onPrevious={goToPreviousStep}
+          onNext={handleNext}
+        />
+      </form>
+    </FormProvider>
   );
 }

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { match } from 'ts-pattern';
-import { bookQueries } from '@/entities/book';
+import { useBookDetail } from '@/entities/book';
 import { BookNoteFormStep } from '../../model/book-note-form-step';
 import ReadingInfoStep from './step/ReadingInfoStep';
 import RatingStep from './step/RatingStep';
@@ -17,7 +16,7 @@ export default function BookNoteForm() {
 
   const { isbn } = useParams<{ isbn: string }>()!;
 
-  const { data: book } = useSuspenseQuery(bookQueries.detail(isbn));
+  const book = useBookDetail(isbn);
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8 p-4 md:p-6">

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { match } from 'ts-pattern';
 import { useFormFunnel } from '@/shared/lib/form';
+import { RenderCase } from '@/shared/ui/render-case';
 import { useBookDetail } from '@/entities/book';
 import BookNoteFormActions from './BookNoteFormActions';
 import ReadingInfoStep from './step/ReadingInfoStep';
@@ -24,13 +24,16 @@ export default function BookNoteForm() {
 
   return (
     <form className="mx-auto w-full max-w-4xl space-y-8 p-4 md:p-6">
-      {match(currentStep)
-        .with(1, () => <ReadingInfoStep book={book} />)
-        .with(2, () => <RatingStep />)
-        .with(3, () => <ReviewStep />)
-        .with(4, () => <QuotesStep />)
-        .with(5, () => <VisibilityStep />)
-        .otherwise(() => null)}
+      <RenderCase
+        value={currentStep}
+        cases={{
+          1: <ReadingInfoStep book={book} />,
+          2: <RatingStep />,
+          3: <ReviewStep />,
+          4: <QuotesStep />,
+          5: <VisibilityStep />,
+        }}
+      />
       <BookNoteFormActions
         previousDisabled={isFirstStep}
         nextDisabled={isLastStep}

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import { match } from 'ts-pattern';
+import { useFormFunnel } from '@/shared/lib/form';
 import { useBookDetail } from '@/entities/book';
-import { BookNoteFormStep } from '../../model/book-note-form-step';
+import BookNoteFormActions from './BookNoteFormActions';
 import ReadingInfoStep from './step/ReadingInfoStep';
 import RatingStep from './step/RatingStep';
 import ReviewStep from './step/ReviewStep';
@@ -12,41 +12,31 @@ import QuotesStep from './step/QuotesStep';
 import VisibilityStep from './step/VisibilityStep';
 
 export default function BookNoteForm() {
-  const [step, setStep] = useState<BookNoteFormStep>(BookNoteFormStep.READING_INFO);
-
   const { isbn } = useParams<{ isbn: string }>()!;
 
   const book = useBookDetail(isbn);
 
+  const { navigation } = useFormFunnel({
+    totalSteps: 5,
+  });
+
+  const { currentStep, isFirstStep, isLastStep, goToPreviousStep, goToNextStep } = navigation;
+
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-8 p-4 md:p-6">
-      {match(step)
-        .with(BookNoteFormStep.READING_INFO, () => (
-          <ReadingInfoStep
-            book={book}
-            onNext={() => setStep(BookNoteFormStep.RATING)}
-          />
-        ))
-        .with(BookNoteFormStep.RATING, () => (
-          <RatingStep
-            onPrevious={() => setStep(BookNoteFormStep.READING_INFO)}
-            onNext={() => setStep(BookNoteFormStep.REVIEW)}
-          />
-        ))
-        .with(BookNoteFormStep.REVIEW, () => (
-          <ReviewStep
-            onPrevious={() => setStep(BookNoteFormStep.RATING)}
-            onNext={() => setStep(BookNoteFormStep.QUOTES)}
-          />
-        ))
-        .with(BookNoteFormStep.QUOTES, () => (
-          <QuotesStep
-            onPrevious={() => setStep(BookNoteFormStep.REVIEW)}
-            onNext={() => setStep(BookNoteFormStep.VISIBILITY)}
-          />
-        ))
-        .with(BookNoteFormStep.VISIBILITY, () => <VisibilityStep onPrevious={() => setStep(BookNoteFormStep.QUOTES)} />)
-        .exhaustive()}
-    </div>
+    <form className="mx-auto w-full max-w-4xl space-y-8 p-4 md:p-6">
+      {match(currentStep)
+        .with(1, () => <ReadingInfoStep book={book} />)
+        .with(2, () => <RatingStep />)
+        .with(3, () => <ReviewStep />)
+        .with(4, () => <QuotesStep />)
+        .with(5, () => <VisibilityStep />)
+        .otherwise(() => null)}
+      <BookNoteFormActions
+        previousDisabled={isFirstStep}
+        nextDisabled={isLastStep}
+        onPrevious={goToPreviousStep}
+        onNext={goToNextStep}
+      />
+    </form>
   );
 }

--- a/src/features/book-note/ui/BookNoteForm/step/QuotesStep.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/QuotesStep.tsx
@@ -3,12 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/shared/ui/card';
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
 import { Textarea } from '@/shared/ui/textarea';
-import BookNoteFormActions from '../BookNoteFormActions';
 
-interface QuotesStepProps {
-  onPrevious?: () => void;
-  onNext?: () => void;
-}
 interface Quote {
   text: string;
   page: string;
@@ -19,54 +14,48 @@ const quotes: Quote[] = [
   { text: '기억에 남는 문구 2', page: '200' },
 ];
 
-export default function QuotesStep({ onPrevious, onNext }: QuotesStepProps) {
+export default function QuotesStep() {
   return (
-    <form>
-      <Card>
-        <CardHeader>
-          <CardTitle>기억에 남는 문구</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {quotes.map((quote: Quote, index: number) => (
-            <div
-              key={index}
-              className="space-y-2"
-            >
-              <div className="flex items-center justify-between">
-                <Label htmlFor={`quote-${index}`}>문구 {index + 1}</Label>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                >
-                  삭제
-                </Button>
-              </div>
-              <Textarea
-                id={`quote-${index}`}
-                defaultValue={quote.text}
-                placeholder="기억에 남는 문구를 입력해 주세요"
-              />
-              <Input
-                type="number"
-                defaultValue={quote.page}
-                placeholder="페이지 번호"
-                className="w-32"
-              />
-            </div>
-          ))}
-          <Button
-            type="button"
-            variant="outline"
+    <Card>
+      <CardHeader>
+        <CardTitle>기억에 남는 문구</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {quotes.map((quote: Quote, index: number) => (
+          <div
+            key={index}
+            className="space-y-2"
           >
-            문구 추가
-          </Button>
-        </CardContent>
-      </Card>
-      <BookNoteFormActions
-        onPrevious={onPrevious}
-        onNext={onNext}
-      />
-    </form>
+            <div className="flex items-center justify-between">
+              <Label htmlFor={`quote-${index}`}>문구 {index + 1}</Label>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+              >
+                삭제
+              </Button>
+            </div>
+            <Textarea
+              id={`quote-${index}`}
+              defaultValue={quote.text}
+              placeholder="기억에 남는 문구를 입력해 주세요"
+            />
+            <Input
+              type="number"
+              defaultValue={quote.page}
+              placeholder="페이지 번호"
+              className="w-32"
+            />
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+        >
+          문구 추가
+        </Button>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/features/book-note/ui/BookNoteForm/step/RatingStep.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/RatingStep.tsx
@@ -2,53 +2,41 @@ import { ThumbsDown, ThumbsUp } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/shared/ui/card';
 import { Label } from '@/shared/ui/label';
-import BookNoteFormActions from '../BookNoteFormActions';
 import StarRating from '../StarRating';
-
-interface RatingStepProps {
-  onPrevious?: () => void;
-  onNext?: () => void;
-}
 
 const recommended = true;
 
-export default function RatingStep({ onPrevious, onNext }: RatingStepProps) {
+export default function RatingStep() {
   return (
-    <form>
-      <Card>
-        <CardHeader>
-          <CardTitle>책 평가</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label>이 책을 추천할까요?</Label>
-            <div className="flex space-x-2">
-              <Button
-                type="button"
-                variant={recommended ? 'default' : 'outline'}
-              >
-                <ThumbsUp className="mr-2 size-5" />
-                추천
-              </Button>
-              <Button
-                type="button"
-                variant={!recommended ? 'default' : 'outline'}
-              >
-                <ThumbsDown className="mr-2 size-5" />
-                추천하지 않음
-              </Button>
-            </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>책 평가</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>이 책을 추천할까요?</Label>
+          <div className="flex space-x-2">
+            <Button
+              type="button"
+              variant={recommended ? 'default' : 'outline'}
+            >
+              <ThumbsUp className="mr-2 size-5" />
+              추천
+            </Button>
+            <Button
+              type="button"
+              variant={!recommended ? 'default' : 'outline'}
+            >
+              <ThumbsDown className="mr-2 size-5" />
+              추천하지 않음
+            </Button>
           </div>
-          <div className="space-y-2">
-            <Label>전체 평점</Label>
-            <StarRating rating={3} />
-          </div>
-        </CardContent>
-      </Card>
-      <BookNoteFormActions
-        onPrevious={onPrevious}
-        onNext={onNext}
-      />
-    </form>
+        </div>
+        <div className="space-y-2">
+          <Label>전체 평점</Label>
+          <StarRating rating={3} />
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/features/book-note/ui/BookNoteForm/step/ReadingInfoStep.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/ReadingInfoStep.tsx
@@ -8,7 +8,6 @@ import { RadioGroup, RadioGroupItem } from '@/shared/ui/radio-group';
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/popover';
 import { BookDetail } from '@/entities/book';
 import { ReadingStatus } from '../../../model/reading-status';
-import BookNoteFormActions from '../BookNoteFormActions';
 
 const readingStatusLabels = {
   [ReadingStatus.WANT_TO_READ]: '읽고 싶어요',
@@ -20,114 +19,107 @@ const readingStatusLabels = {
 
 interface ReadingInfoStepProps {
   book: BookDetail;
-  onNext?: () => void;
 }
 
-export default function ReadingInfoStep({ book, onNext }: ReadingInfoStepProps) {
+export default function ReadingInfoStep({ book }: ReadingInfoStepProps) {
   return (
-    <form>
-      <Card>
-        <CardHeader>
-          <CardTitle>{book.title}</CardTitle>
-          <CardDescription>by {book.author}</CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-6">
-          <div className="flex flex-col items-start space-y-4 md:flex-row md:items-center md:space-x-4 md:space-y-0">
-            <div className="space-y-2">
-              <Image
-                src={book.coverImage}
-                alt={`${book.title} 표지`}
-                width={200}
-                height={300}
-                className="object-cover"
-              />
-              <p>
-                <strong>출판사:</strong> {book.publisher}
-              </p>
-              <p>
-                <strong>ISBN:</strong> {book.isbn}
-              </p>
-              <p>
-                <strong>페이지:</strong> {book.pageCount}쪽
-              </p>
-            </div>
-          </div>
-          {!!book.description && (
-            <div>
-              <strong>설명:</strong>
-              <p className="mt-2">{book.description}</p>
-            </div>
-          )}
+    <Card>
+      <CardHeader>
+        <CardTitle>{book.title}</CardTitle>
+        <CardDescription>by {book.author}</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-6">
+        <div className="flex flex-col items-start space-y-4 md:flex-row md:items-center md:space-x-4 md:space-y-0">
           <div className="space-y-2">
-            <Label>읽기 상태</Label>
-            <RadioGroup>
-              {Object.values(ReadingStatus).map((status) => (
-                <div
-                  key={status}
-                  className="flex items-center space-x-2"
+            <Image
+              src={book.coverImage}
+              alt={`${book.title} 표지`}
+              width={200}
+              height={300}
+              className="object-cover"
+            />
+            <p>
+              <strong>출판사:</strong> {book.publisher}
+            </p>
+            <p>
+              <strong>ISBN:</strong> {book.isbn}
+            </p>
+            <p>
+              <strong>페이지:</strong> {book.pageCount}쪽
+            </p>
+          </div>
+        </div>
+        {!!book.description && (
+          <div>
+            <strong>설명:</strong>
+            <p className="mt-2">{book.description}</p>
+          </div>
+        )}
+        <div className="space-y-2">
+          <Label>읽기 상태</Label>
+          <RadioGroup>
+            {Object.values(ReadingStatus).map((status) => (
+              <div
+                key={status}
+                className="flex items-center space-x-2"
+              >
+                <RadioGroupItem
+                  value={status}
+                  id={status}
+                />
+                <Label
+                  className="cursor-pointer"
+                  htmlFor={status}
                 >
-                  <RadioGroupItem
-                    value={status}
-                    id={status}
-                  />
-                  <Label
-                    className="cursor-pointer"
-                    htmlFor={status}
-                  >
-                    {readingStatusLabels[status]}
-                  </Label>
-                </div>
-              ))}
-            </RadioGroup>
+                  {readingStatusLabels[status]}
+                </Label>
+              </div>
+            ))}
+          </RadioGroup>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="startDate">읽기 시작한 날짜</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start text-left font-normal"
+                >
+                  <CalendarIcon className="mr-2 size-4" />
+                  <span>날짜 선택</span>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
           </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="startDate">읽기 시작한 날짜</Label>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start text-left font-normal"
-                  >
-                    <CalendarIcon className="mr-2 size-4" />
-                    <span>날짜 선택</span>
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="endDate">읽은 마지막 날짜</Label>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start text-left font-normal"
-                  >
-                    <CalendarIcon className="mr-2 size-4" />
-                    <span>날짜 선택</span>
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
-            </div>
+          <div className="space-y-2">
+            <Label htmlFor="endDate">읽은 마지막 날짜</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start text-left font-normal"
+                >
+                  <CalendarIcon className="mr-2 size-4" />
+                  <span>날짜 선택</span>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
           </div>
-        </CardContent>
-      </Card>
-      <BookNoteFormActions
-        previousDisabled
-        onNext={onNext}
-      />
-    </form>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/features/book-note/ui/BookNoteForm/step/ReviewStep.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/ReviewStep.tsx
@@ -1,32 +1,20 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/shared/ui/card';
 import { Textarea } from '@/shared/ui/textarea';
-import BookNoteFormActions from '../BookNoteFormActions';
 
-interface ReviewStepProps {
-  onPrevious?: () => void;
-  onNext?: () => void;
-}
-
-export default function ReviewStep({ onPrevious, onNext }: ReviewStepProps) {
+export default function ReviewStep() {
   return (
-    <form>
-      <Card>
-        <CardHeader>
-          <CardTitle>독후감</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Textarea
-            id="content"
-            name="content"
-            className="min-h-[200px]"
-            placeholder="독후감을 작성해 보세요!"
-          />
-        </CardContent>
-      </Card>
-      <BookNoteFormActions
-        onPrevious={onPrevious}
-        onNext={onNext}
-      />
-    </form>
+    <Card>
+      <CardHeader>
+        <CardTitle>독후감</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Textarea
+          id="content"
+          name="content"
+          className="min-h-[200px]"
+          placeholder="독후감을 작성해 보세요!"
+        />
+      </CardContent>
+    </Card>
   );
 }

--- a/src/features/book-note/ui/BookNoteForm/step/VisibilityStep.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/VisibilityStep.tsx
@@ -1,30 +1,22 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/shared/ui/card';
 import { Label } from '@/shared/ui/label';
 import { Switch } from '@/shared/ui/switch';
-import BookNoteFormActions from '../BookNoteFormActions';
 
-interface VisibilityStepProps {
-  onPrevious?: () => void;
-}
-
-export default function VisibilityStep({ onPrevious }: VisibilityStepProps) {
+export default function VisibilityStep() {
   return (
-    <form>
-      <Card>
-        <CardHeader>
-          <CardTitle>노트 공개 설정</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center space-x-2">
-            <Switch
-              id="visibility"
-              checked
-            />
-            <Label htmlFor="visibility">전체 공개</Label>
-          </div>
-        </CardContent>
-      </Card>
-      <BookNoteFormActions onPrevious={onPrevious} />
-    </form>
+    <Card>
+      <CardHeader>
+        <CardTitle>노트 공개 설정</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center space-x-2">
+          <Switch
+            id="visibility"
+            checked
+          />
+          <Label htmlFor="visibility">전체 공개</Label>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/shared/lib/form.ts
+++ b/src/shared/lib/form.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
+import { isNil } from 'es-toolkit';
+import { FieldValues, useForm, UseFormProps, UseFormReturn } from 'react-hook-form';
+
+const FIRST_FUNNEL_STEP = 1;
+
+export function useFunnelNavigation(totalSteps: number) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const funnelStepParam = searchParams?.get('funnelStep');
+  const currentStep = isNil(funnelStepParam) ? FIRST_FUNNEL_STEP : Number(funnelStepParam);
+  const isFirstStep = currentStep === FIRST_FUNNEL_STEP;
+  const isLastStep = currentStep === totalSteps;
+
+  const navigateToStep = useCallback(
+    (step: number, replace = false) => {
+      const params = new URLSearchParams({ funnelStep: step.toString() });
+      const url = `${pathname}?${params}`;
+      if (replace) router.replace(url);
+      else router.push(url);
+    },
+    [pathname, router],
+  );
+
+  useEffect(() => {
+    if (isNil(funnelStepParam) || Number(funnelStepParam) > totalSteps) {
+      navigateToStep(FIRST_FUNNEL_STEP);
+    }
+  }, [funnelStepParam, totalSteps, pathname, router, navigateToStep]);
+
+  return {
+    currentStep,
+    isFirstStep,
+    isLastStep,
+    navigateToStep,
+  };
+}
+
+export interface UseFormFunnelProps<TFieldValues extends FieldValues = FieldValues, TContext = unknown>
+  extends UseFormProps<TFieldValues, TContext> {
+  totalSteps: number;
+}
+
+export interface FunnelNavigation {
+  currentStep: number;
+  isFirstStep: boolean;
+  isLastStep: boolean;
+  goToPreviousStep: () => void;
+  goToNextStep: () => void;
+}
+
+export interface UseFormFunnelReturn<TFieldValues extends FieldValues = FieldValues, TContext = unknown> {
+  form: UseFormReturn<TFieldValues, TContext>;
+  navigation: FunnelNavigation;
+}
+
+export function useFormFunnel<TFieldValues extends FieldValues = FieldValues, TContext = unknown>({
+  totalSteps,
+  ...formProps
+}: UseFormFunnelProps<TFieldValues, TContext>): UseFormFunnelReturn<TFieldValues, TContext> {
+  const form = useForm<TFieldValues, TContext>(formProps);
+
+  const { currentStep, isFirstStep, isLastStep, navigateToStep } = useFunnelNavigation(totalSteps);
+
+  const goToPreviousStep = () => {
+    if (!isFirstStep) {
+      navigateToStep(currentStep - 1);
+    }
+  };
+
+  const goToNextStep = () => {
+    if (!isLastStep) {
+      navigateToStep(currentStep + 1);
+    }
+  };
+
+  const navigation: FunnelNavigation = {
+    currentStep,
+    isFirstStep,
+    isLastStep,
+    goToPreviousStep,
+    goToNextStep,
+  };
+
+  return {
+    form,
+    navigation,
+  };
+}

--- a/src/shared/ui/form.tsx
+++ b/src/shared/ui/form.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import {
+  ComponentPropsWithoutRef,
+  createContext,
+  ElementRef,
+  forwardRef,
+  HTMLAttributes,
+  useContext,
+  useId,
+} from 'react';
+import { Root as LabelRoot } from '@radix-ui/react-label';
+import { Slot } from '@radix-ui/react-slot';
+import { Controller, ControllerProps, FieldPath, FieldValues, FormProvider, useFormContext } from 'react-hook-form';
+import { cn } from '@/shared/lib/utils';
+import { Label } from '@/shared/ui/label';
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = createContext<FormFieldContextValue>({} as FormFieldContextValue);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = useContext(FormFieldContext);
+  const itemContext = useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>');
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = createContext<FormItemContextValue>({} as FormItemContextValue);
+
+const FormItem = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => {
+  const id = useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        ref={ref}
+        className={cn('space-y-2', className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  );
+});
+FormItem.displayName = 'FormItem';
+
+const FormLabel = forwardRef<ElementRef<typeof LabelRoot>, ComponentPropsWithoutRef<typeof LabelRoot>>(
+  ({ className, ...props }, ref) => {
+    const { error, formItemId } = useFormField();
+
+    return (
+      <Label
+        ref={ref}
+        className={cn(error && 'text-destructive', className)}
+        htmlFor={formItemId}
+        {...props}
+      />
+    );
+  },
+);
+FormLabel.displayName = 'FormLabel';
+
+const FormControl = forwardRef<ElementRef<typeof Slot>, ComponentPropsWithoutRef<typeof Slot>>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
+FormControl.displayName = 'FormControl';
+
+const FormDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => {
+    const { formDescriptionId } = useFormField();
+
+    return (
+      <p
+        ref={ref}
+        id={formDescriptionId}
+        className={cn('text-[0.8rem] text-muted-foreground', className)}
+        {...props}
+      />
+    );
+  },
+);
+FormDescription.displayName = 'FormDescription';
+
+const FormMessage = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, children, ...props }, ref) => {
+    const { error, formMessageId } = useFormField();
+    const body = error ? String(error?.message) : children;
+
+    if (!body) {
+      return null;
+    }
+
+    return (
+      <p
+        ref={ref}
+        id={formMessageId}
+        className={cn('text-[0.8rem] font-medium text-destructive', className)}
+        {...props}
+      >
+        {body}
+      </p>
+    );
+  },
+);
+FormMessage.displayName = 'FormMessage';
+
+export { useFormField, Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };

--- a/src/shared/ui/render-case.tsx
+++ b/src/shared/ui/render-case.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+export interface RenderCaseProps<T extends string | number | symbol> {
+  value: T;
+  cases: Record<T, ReactNode>;
+}
+
+export function RenderCase<T extends string | number | symbol>({ value, cases }: RenderCaseProps<T>) {
+  return cases[value];
+}


### PR DESCRIPTION
지난 멘토링 때 피드백 받은 내용 중 `useFormFunnel`과 `Switch(RenderCase)` 컴포넌트만 우선 반영했습니다.

### useFormFunnel

- `useFormFunnel`의 파라미터는 rhf의 `useForm`과 같습니다.
- `useFormFunnel`은 `form`과 `navigation`를 포함하는 객체를 리턴합니다.
  - `form`은 `useForm`의 리턴과 같습니다.
  - `navigation`은 스텝 이동과 관련된 값과 함수를 갖습니다.

### Switch(RenderCase)

- `Switch`라는 이름을 기존에 on/off를 토글하는 UI 컴포넌트가 사용하고 있어서 클로드의 추천을 받아 `RenderCase`라는 컴포넌트를 추가했습니다.

### 기타

- 위 두 컴포넌트를 기반으로 폼과 스텝 컴포넌트를 수정했고, 내부적인 로직의 변화는 없습니다.