### PR TITLE
[#16] CommaSeparatedInput 구현 및 피드백 적용

### DIFF
--- a/src/features/book-note/model/book-note-form-schema.ts
+++ b/src/features/book-note/model/book-note-form-schema.ts
@@ -1,16 +1,13 @@
 import { z } from 'zod';
+import { requiredNullable } from '@/shared/lib/zod-utils';
 import { readingInfoSchema } from './reading-info-schema';
 import { createQuoteSchema } from './quotes-schema';
 
 export function createBookNoteFormSchema(pageCount: number) {
   return z.object({
     readingInfo: readingInfoSchema,
-    recommended: z.boolean({
-      required_error: '추천 여부는 필수 값입니다.',
-    }),
-    rating: z.number({
-      required_error: '전체 평점은 필수 값입니다.',
-    }),
+    recommended: requiredNullable(z.boolean(), '추천 여부는 필수 값입니다.'),
+    rating: requiredNullable(z.number(), '전체 평점은 필수 값입니다.'),
     review: z.string().min(1, {
       message: '독후감은 필수 값입니다.',
     }),

--- a/src/features/book-note/model/quotes-schema.ts
+++ b/src/features/book-note/model/quotes-schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { isEmpty } from '@/shared/lib/string-utils';
+import { isNil } from 'es-toolkit';
 
 const quoteSchema = z.object({
   text: z.string().trim().min(1, {
     message: '기억에 남는 문구는 필수 값입니다.',
   }),
-  page: z.string(),
+  page: z.number().nullable(),
 });
 
 export function createQuoteSchema(pageCount: number) {
@@ -18,7 +18,7 @@ export function createQuoteSchema(pageCount: number) {
       if (data.length < 2) return;
 
       for (const [index, quote] of data.entries()) {
-        if (isEmpty(quote.page)) {
+        if (isNil(quote.page)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: '페이지를 입력해 주세요.',

--- a/src/features/book-note/model/reading-info-schema.ts
+++ b/src/features/book-note/model/reading-info-schema.ts
@@ -1,5 +1,6 @@
 import { isNil, isNotNil } from 'es-toolkit';
 import { z } from 'zod';
+import { requiredNullable } from '@/shared/lib/zod-utils';
 import { ReadingStatus } from './reading-status';
 
 interface ValidationRule {
@@ -52,13 +53,13 @@ const validationRules: Partial<Record<ReadingStatus, Record<'startDate' | 'endDa
 
 export const readingInfoSchema = z
   .object({
-    readingStatus: z.nativeEnum(ReadingStatus, {
-      required_error: '읽기 상태는 필수 값입니다.',
-    }),
-    startDate: z.date().optional(),
-    endDate: z.date().optional(),
+    readingStatus: requiredNullable(z.nativeEnum(ReadingStatus), '읽기 상태는 필수 값입니다.'),
+    startDate: z.date().nullable(),
+    endDate: z.date().nullable(),
   })
   .superRefine((data, ctx) => {
+    if (isNil(data.readingStatus)) return;
+
     const rules = validationRules[data.readingStatus];
     if (isNil(rules)) return;
 

--- a/src/features/book-note/model/step-fields.ts
+++ b/src/features/book-note/model/step-fields.ts
@@ -1,0 +1,9 @@
+import { BookNoteFormSchema } from './book-note-form-schema';
+
+export const stepFields = new Map<number, (keyof BookNoteFormSchema)[]>([
+  [1, ['readingInfo']],
+  [2, ['recommended', 'rating']],
+  [3, ['review']],
+  [4, ['quotes']],
+  [5, ['publish']],
+]);

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -11,20 +11,13 @@ import { Form } from '@/shared/ui/form';
 import { RenderCase } from '@/shared/ui/render-case';
 import { useBookDetail } from '@/entities/book';
 import { BookNoteFormSchema, createBookNoteFormSchema } from '../../model/book-note-form-schema';
+import { stepFields } from '../../model/step-fields';
 import BookNoteFormActions from './BookNoteFormActions';
 import ReadingInfoStep from './step/ReadingInfoStep';
 import RatingStep from './step/RatingStep';
 import ReviewStep from './step/ReviewStep';
 import QuotesStep from './step/QuotesStep';
 import PublishStep from './step/PublishStep';
-
-const triggerFields = new Map<number, (keyof BookNoteFormSchema)[]>([
-  [1, ['readingInfo']],
-  [2, ['recommended', 'rating']],
-  [3, ['review']],
-  [4, ['quotes']],
-  [5, ['publish']],
-]);
 
 const defaultValues: BookNoteFormSchema = {
   readingInfo: {
@@ -53,7 +46,7 @@ export default function BookNoteForm() {
 
   const onStepChange = useCallback(
     (step: number) => {
-      for (const field of triggerFields.get(step) ?? []) {
+      for (const field of stepFields.get(step) ?? []) {
         const error = form.formState.errors[field];
         if (isNotNil(error)) {
           form.setFocus(field);
@@ -74,7 +67,7 @@ export default function BookNoteForm() {
   };
 
   const onError = (errors: FieldErrors<BookNoteFormSchema>) => {
-    for (const [step, fields] of triggerFields.entries()) {
+    for (const [step, fields] of stepFields.entries()) {
       for (const field of fields) {
         if (isNotNil(errors[field])) {
           funnel.goToStep(step);

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -26,6 +26,19 @@ const triggerFields = new Map<number, (keyof BookNoteFormSchema)[]>([
   [5, ['publish']],
 ]);
 
+const defaultValues: BookNoteFormSchema = {
+  readingInfo: {
+    readingStatus: null,
+    startDate: null,
+    endDate: null,
+  },
+  recommended: null,
+  rating: null,
+  review: '',
+  quotes: [],
+  publish: false,
+};
+
 export default function BookNoteForm() {
   const { isbn } = useParams<{ isbn: string }>()!;
 
@@ -35,18 +48,7 @@ export default function BookNoteForm() {
 
   const form = useForm<BookNoteFormSchema>({
     resolver,
-    defaultValues: {
-      readingInfo: {
-        readingStatus: undefined,
-        startDate: undefined,
-        endDate: undefined,
-      },
-      recommended: undefined,
-      rating: undefined,
-      review: '',
-      quotes: [],
-      publish: false,
-    },
+    defaultValues,
   });
 
   const onStepChange = useCallback(

--- a/src/features/book-note/ui/BookNoteForm/BookNoteFormActions.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteFormActions.tsx
@@ -2,14 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { useFunnelContext } from '@/shared/lib/funnel';
 import { Button } from '@/shared/ui/button';
 import { BookNoteFormSchema } from '../../model/book-note-form-schema';
-
-const triggerFields: Record<number, (keyof BookNoteFormSchema)[]> = {
-  1: ['readingInfo'],
-  2: ['recommended', 'rating'],
-  3: ['review'],
-  4: ['quotes'],
-  5: ['publish'],
-};
+import { stepFields } from '../../model/step-fields';
 
 interface BookNoteFormActionsProps {
   previousLabel?: string;
@@ -26,7 +19,7 @@ export default function BookNoteFormActions({
   const { currentStep, isFirstStep, isLastStep, goToPreviousStep, goToNextStep } = useFunnelContext();
 
   const handleNext = async () => {
-    const isValid = await trigger(triggerFields[currentStep], { shouldFocus: true });
+    const isValid = await trigger(stepFields.get(currentStep), { shouldFocus: true });
     if (isValid) goToNextStep();
   };
 

--- a/src/features/book-note/ui/BookNoteForm/step/QuotesStep/QuotesField.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/QuotesStep/QuotesField.tsx
@@ -1,14 +1,15 @@
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { isNotNil } from 'es-toolkit';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
-import { Input } from '@/shared/ui/input';
+import { CommaSeparatedInput } from '@/shared/ui/comma-separated-input';
 import { Label } from '@/shared/ui/label';
 import { Textarea } from '@/shared/ui/textarea';
 import { BookNoteFormSchema } from '../../../../model/book-note-form-schema';
 
 export default function QuotesField() {
   const {
+    control,
     register,
     formState: { errors },
   } = useFormContext<BookNoteFormSchema>();
@@ -48,13 +49,18 @@ export default function QuotesField() {
               {errors.quotes[index].text.message}
             </p>
           )}
-          <Input
-            {...register(`quotes.${index}.page`)}
-            type="number"
-            placeholder="페이지 번호"
-            className={cn(isNotNil(errors.quotes?.[index]?.page) && 'border-red-500 focus-visible:ring-red-500')}
-            aria-describedby={isNotNil(errors.quotes?.[index]?.page) ? `quote-${index}-page-error` : undefined}
-            aria-invalid={isNotNil(errors.quotes?.[index]?.page)}
+          <Controller
+            control={control}
+            name={`quotes.${index}.page`}
+            render={({ field }) => (
+              <CommaSeparatedInput
+                {...field}
+                placeholder="페이지 번호"
+                className={cn(isNotNil(errors.quotes?.[index]?.page) && 'border-red-500 focus-visible:ring-red-500')}
+                aria-describedby={isNotNil(errors.quotes?.[index]?.page) ? `quote-${index}-page-error` : undefined}
+                aria-invalid={isNotNil(errors.quotes?.[index]?.page)}
+              />
+            )}
           />
           {isNotNil(errors.quotes?.[index]?.page) && (
             <p
@@ -70,7 +76,7 @@ export default function QuotesField() {
       <Button
         type="button"
         variant="outline"
-        onClick={() => append({ text: '', page: '' })}
+        onClick={() => append({ text: '', page: null })}
       >
         문구 추가
       </Button>

--- a/src/features/book-note/ui/BookNoteForm/step/QuotesStep/QuotesField.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/QuotesStep/QuotesField.tsx
@@ -1,15 +1,14 @@
-import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import { isNotNil } from 'es-toolkit';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
-import { CommaSeparatedInput } from '@/shared/ui/comma-separated-input';
+import { RHFCommaSeparatedInput } from '@/shared/ui/comma-separated-input';
 import { Label } from '@/shared/ui/label';
 import { Textarea } from '@/shared/ui/textarea';
 import { BookNoteFormSchema } from '../../../../model/book-note-form-schema';
 
 export default function QuotesField() {
   const {
-    control,
     register,
     formState: { errors },
   } = useFormContext<BookNoteFormSchema>();
@@ -49,18 +48,12 @@ export default function QuotesField() {
               {errors.quotes[index].text.message}
             </p>
           )}
-          <Controller
-            control={control}
+          <RHFCommaSeparatedInput
             name={`quotes.${index}.page`}
-            render={({ field }) => (
-              <CommaSeparatedInput
-                {...field}
-                placeholder="페이지 번호"
-                className={cn(isNotNil(errors.quotes?.[index]?.page) && 'border-red-500 focus-visible:ring-red-500')}
-                aria-describedby={isNotNil(errors.quotes?.[index]?.page) ? `quote-${index}-page-error` : undefined}
-                aria-invalid={isNotNil(errors.quotes?.[index]?.page)}
-              />
-            )}
+            placeholder="페이지 번호"
+            className={cn(isNotNil(errors.quotes?.[index]?.page) && 'border-red-500 focus-visible:ring-red-500')}
+            aria-describedby={isNotNil(errors.quotes?.[index]?.page) ? `quote-${index}-page-error` : undefined}
+            aria-invalid={isNotNil(errors.quotes?.[index]?.page)}
           />
           {isNotNil(errors.quotes?.[index]?.page) && (
             <p

--- a/src/features/book-note/ui/BookNoteForm/step/ReadingInfoStep/ReadingStatusField.tsx
+++ b/src/features/book-note/ui/BookNoteForm/step/ReadingInfoStep/ReadingStatusField.tsx
@@ -33,7 +33,7 @@ export default function ReadingStatusField() {
         name="readingInfo.readingStatus"
         render={({ field }) => (
           <Select
-            value={field.value}
+            value={field.value ?? undefined}
             onValueChange={field.onChange}
           >
             <SelectTrigger

--- a/src/shared/lib/zod-utils.ts
+++ b/src/shared/lib/zod-utils.ts
@@ -1,0 +1,13 @@
+import { isNull } from 'es-toolkit';
+import { z } from 'zod';
+
+export function requiredNullable<T extends z.ZodTypeAny>(schema: T, message: string): z.ZodType<z.infer<T> | null> {
+  return schema.nullable().superRefine((val, ctx) => {
+    if (isNull(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message,
+      });
+    }
+  });
+}

--- a/src/shared/ui/comma-separated-input.tsx
+++ b/src/shared/ui/comma-separated-input.tsx
@@ -1,0 +1,47 @@
+import { ChangeEvent, ComponentProps } from 'react';
+import { isNil } from 'es-toolkit';
+import { Input } from '@/shared/ui/input';
+
+type InputProps = ComponentProps<typeof Input>;
+
+interface CommaSeparatedInputProps extends Omit<InputProps, 'type' | 'value' | 'onChange'> {
+  value?: number | null;
+  onChange?: (value: number | null) => void;
+}
+
+const formatNumberWithCommas = (value?: number | null) => {
+  return isNil(value) ? '' : value.toLocaleString();
+};
+
+const parseCommaSeparatedNumber = (value: string) => {
+  if (!value.trim()) return null;
+
+  const num = Number(value.replaceAll(',', ''));
+
+  return isNaN(num) ? null : num;
+};
+
+const SAFE_INTEGER_INPUT_LENGTH = 19;
+
+const CommaSeparatedInput = ({
+  value,
+  maxLength = SAFE_INTEGER_INPUT_LENGTH,
+  onChange,
+  ...props
+}: CommaSeparatedInputProps) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(parseCommaSeparatedNumber(e.target.value));
+  };
+
+  return (
+    <Input
+      {...props}
+      type="text"
+      value={formatNumberWithCommas(value)}
+      maxLength={Math.min(maxLength, SAFE_INTEGER_INPUT_LENGTH)}
+      onChange={handleChange}
+    />
+  );
+};
+
+export { CommaSeparatedInput };

--- a/src/shared/ui/comma-separated-input.tsx
+++ b/src/shared/ui/comma-separated-input.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, ComponentProps } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
 import { isNil } from 'es-toolkit';
 import { Input } from '@/shared/ui/input';
 
@@ -44,4 +45,25 @@ const CommaSeparatedInput = ({
   );
 };
 
-export { CommaSeparatedInput };
+interface RHFCommaSeparatedInputProps extends CommaSeparatedInputProps {
+  name: string;
+}
+
+const RHFCommaSeparatedInput = ({ name, ...props }: RHFCommaSeparatedInputProps) => {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <CommaSeparatedInput
+          {...field}
+          {...props}
+        />
+      )}
+    />
+  );
+};
+
+export { CommaSeparatedInput, RHFCommaSeparatedInput };

--- a/src/shared/ui/date-picker.tsx
+++ b/src/shared/ui/date-picker.tsx
@@ -1,3 +1,4 @@
+import { Ref } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { isNil, isNotNil } from 'es-toolkit';
@@ -6,12 +7,11 @@ import { cn } from '@/shared/lib/utils';
 import { Button, ButtonProps } from './button';
 import { Calendar } from './calendar';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
-import { Ref } from 'react';
 
 interface DatePickerProps extends Omit<ButtonProps, 'value' | 'onChange'> {
   ref?: Ref<HTMLButtonElement>;
   placeholder?: string;
-  value?: Date;
+  value?: Date | null;
   onChange?: (date?: Date) => void;
 }
 
@@ -37,7 +37,7 @@ const DatePicker = ({ ref, className, placeholder = '날짜 선택', value, onCh
         <Calendar
           mode="single"
           initialFocus
-          selected={value}
+          selected={value ?? undefined}
           onSelect={onChange}
         />
       </PopoverContent>

--- a/src/shared/ui/star-rating.tsx
+++ b/src/shared/ui/star-rating.tsx
@@ -7,12 +7,14 @@ import { cn } from '@/shared/lib/utils';
 interface StarRatingProps {
   ref?: Ref<HTMLDivElement>;
   className?: string;
-  value: number;
+  value?: number | null;
   onChange?: (rating: number) => void;
 }
 
+const DEFAULT_VALUE = 0;
+
 const StarRating = ({ ref, className, value, onChange }: StarRatingProps) => {
-  const [hovered, setHovered] = useState(value);
+  const [hovered, setHovered] = useState(value ?? DEFAULT_VALUE);
 
   return (
     <div
@@ -24,7 +26,7 @@ const StarRating = ({ ref, className, value, onChange }: StarRatingProps) => {
           key={star}
           onClick={() => onChange?.(hovered)}
           onMouseEnter={() => setHovered(star)}
-          onMouseLeave={() => setHovered(value)}
+          onMouseLeave={() => setHovered(value ?? DEFAULT_VALUE)}
           className={cn('size-6 cursor-pointer', star <= hovered ? 'fill-yellow-400 text-yellow-400' : 'text-gray-300')}
         />
       ))}


### PR DESCRIPTION
## 작업사항

- [x] `CommaSeparatedInput`, `RHFCommaSeparatedInput` 구현 및 적용
  - `QuotesField` 페이지 번호 입력에 적용
- [x] `defaultValues`에 `undefined` 대신 `null` 사용

## 질문

`defaultValues`에 `undefined` 대신 `null`을 적용하려니깐 몇 가지 애로 사항이 있었는데요.

1. 기본값에 `null`을 주려면 `zod`에서 스키마를 정의할 때 `nullable`로 지정을 해야 하는데요. 문제는 `nullable`로 지정하다 보니깐 유효한 값이 없어도 `required` 유효성 검사를 스킵을 하게 되더라고요. `nullable` 하면서도 `required` 유효성 검사가 적용되게 하려고 `requiredNullable`이라는 유틸 함수를 만들어서 적용했는데 괜찮은 방법인지 의견을 듣고 싶습니다.

2. `DatePicker` 같은 컴포넌트를 보면 `selected={value ?? undefined}` 같이 `value`가 `null`일 경우, `undefined`가 되도록 한 게 있는데요. 이게 컴포넌트마다 차이가 있지만 기반이 되는 컴포넌트가 `undefined`는 허용해도 `null`은 허용하지 않는 경우가 많더라고요. 좀 우아하지 않은 방법 같은데 기본 값을 `null`로 했을 때 이런 코드는 어쩔 수 없는 걸까요?