### PR TITLE
[#20] 새로고침 시 폼 유지

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-error-boundary": "^5.0.0",
     "react-hook-form": "^7.54.2",
     "react-intersection-observer": "^9.15.1",
+    "superjson": "^2.2.2",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "ts-pattern": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-intersection-observer:
         specifier: ^9.15.1
         version: 9.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      superjson:
+        specifier: ^2.2.2
+        version: 2.2.2
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -1195,6 +1198,10 @@ packages:
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -1786,6 +1793,10 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2518,6 +2529,10 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superjson@2.2.2:
+    resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
+    engines: {node: '>=16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3786,6 +3801,10 @@ snapshots:
 
   convert-source-map@1.9.0: {}
 
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -4526,6 +4545,8 @@ snapshots:
       call-bound: 1.0.3
       get-intrinsic: 1.2.7
 
+  is-what@4.1.16: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -5250,6 +5271,10 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
+
+  superjson@2.2.2:
+    dependencies:
+      copy-anything: 3.0.5
 
   supports-color@7.2.0:
     dependencies:

--- a/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
+++ b/src/features/book-note/ui/BookNoteForm/BookNoteForm.tsx
@@ -3,9 +3,10 @@
 import { useCallback, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import { isNotNil } from 'es-toolkit';
-import { FieldErrors, useForm } from 'react-hook-form';
+import { FieldErrors } from 'react-hook-form';
 import { DevTool } from '@hookform/devtools';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { usePersistentForm } from '@/shared/lib/form';
 import { FunnelProvider, useFunnel } from '@/shared/lib/funnel';
 import { Form } from '@/shared/ui/form';
 import { RenderCase } from '@/shared/ui/render-case';
@@ -39,9 +40,11 @@ export default function BookNoteForm() {
 
   const resolver = useMemo(() => zodResolver(createBookNoteFormSchema(book.pageCount)), [book.pageCount]);
 
-  const form = useForm<BookNoteFormSchema>({
+  const form = usePersistentForm<BookNoteFormSchema>({
     resolver,
     defaultValues,
+    storage: 'session',
+    storageKey: `book-note-form-${isbn}`,
   });
 
   const onStepChange = useCallback(
@@ -63,6 +66,7 @@ export default function BookNoteForm() {
   });
 
   const onSubmit = (data: BookNoteFormSchema) => {
+    form.clearPersistentData();
     console.log(data);
   };
 

--- a/src/shared/lib/form/index.ts
+++ b/src/shared/lib/form/index.ts
@@ -1,0 +1,1 @@
+export * from './use-persistent-form';

--- a/src/shared/lib/form/use-persistent-form.ts
+++ b/src/shared/lib/form/use-persistent-form.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { FieldValues, useForm, UseFormProps, UseFormReturn } from 'react-hook-form';
+import { isNil } from 'es-toolkit';
+import { isEmpty } from '@/shared/lib/string-utils';
+
+export type PersistentStorage = 'local' | 'session';
+
+export interface UsePersistentFormProps<TFieldValues extends FieldValues = FieldValues, TContext = unknown>
+  extends UseFormProps<TFieldValues, TContext> {
+  storage?: PersistentStorage;
+  storageKey: string;
+}
+
+export interface UsePersistentFormReturn<
+  TFieldValues extends FieldValues = FieldValues,
+  TContext = unknown,
+  TTransformedValues extends FieldValues | undefined = undefined,
+> extends UseFormReturn<TFieldValues, TContext, TTransformedValues> {
+  clearPersistentData: () => void;
+}
+
+const isServer = typeof window === 'undefined';
+
+export function usePersistentForm<
+  TFieldValues extends FieldValues = FieldValues,
+  TContext = unknown,
+  TTransformedValues extends FieldValues | undefined = undefined,
+>({
+  storage = 'local',
+  storageKey,
+  ...formProps
+}: UsePersistentFormProps<TFieldValues, TContext>): UsePersistentFormReturn<
+  TFieldValues,
+  TContext,
+  TTransformedValues
+> {
+  const isStorageKeyEmpty = useMemo(() => isEmpty(storageKey), [storageKey]);
+  const storageApi = useMemo(() => {
+    if (isServer) return null;
+    return storage === 'local' ? localStorage : sessionStorage;
+  }, [storage]);
+
+  const defaultValues = useMemo(() => {
+    if (isServer || isStorageKeyEmpty) return formProps.defaultValues;
+
+    const saved = storageApi?.getItem(storageKey);
+
+    if (isNil(saved)) return formProps.defaultValues;
+
+    return JSON.parse(saved);
+  }, [formProps.defaultValues, isStorageKeyEmpty, storageKey, storageApi]);
+
+  const form = useForm<TFieldValues, TContext, TTransformedValues>({
+    ...formProps,
+    defaultValues,
+  });
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (isStorageKeyEmpty) return;
+      storageApi?.setItem(storageKey, JSON.stringify(form.getValues()));
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [form, isStorageKeyEmpty, storage, storageApi, storageKey]);
+
+  const clearPersistentData = useCallback(() => {
+    if (isStorageKeyEmpty) return;
+    storageApi?.removeItem(storageKey);
+  }, [isStorageKeyEmpty, storageApi, storageKey]);
+
+  return { ...form, clearPersistentData };
+}

--- a/src/shared/lib/form/use-persistent-form.ts
+++ b/src/shared/lib/form/use-persistent-form.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { FieldValues, useForm, UseFormProps, UseFormReturn } from 'react-hook-form';
+import { DefaultValues, FieldValues, useForm, UseFormProps, UseFormReturn } from 'react-hook-form';
 import { isNil } from 'es-toolkit';
+import { parse, stringify } from 'superjson';
 import { isEmpty } from '@/shared/lib/string-utils';
 
 export type PersistentStorage = 'local' | 'session';
@@ -47,7 +48,7 @@ export function usePersistentForm<
 
     if (isNil(saved)) return formProps.defaultValues;
 
-    return JSON.parse(saved);
+    return parse<DefaultValues<TFieldValues>>(saved);
   }, [formProps.defaultValues, isStorageKeyEmpty, storageKey, storageApi]);
 
   const form = useForm<TFieldValues, TContext, TTransformedValues>({
@@ -58,7 +59,7 @@ export function usePersistentForm<
   useEffect(() => {
     const handleBeforeUnload = () => {
       if (isStorageKeyEmpty) return;
-      storageApi?.setItem(storageKey, JSON.stringify(form.getValues()));
+      storageApi?.setItem(storageKey, stringify(form.getValues()));
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);


### PR DESCRIPTION
### 작업사항

- `useForm`을 한 번 래핑해서 form 데이터를 웹 스토리지에 저장할 수 있는 `usePersistentForm`을 구현했습니다.
- 파라미터로 `storage`와 `storageKey`를 받습니다.
  - `storage`로 로컬 스토리지(`local`)나 세션 스토리지(`session`)를 선택할 수 있습니다. 기본 값은 로컬 스토리지입니다.
  - `storageKey`로 저장할 키를 받습니다.
- 리턴한 `clearPersistentData`를 호출해서 저장한 데이터를 삭제할 수 있습니다.